### PR TITLE
Implement Release CI Workflow for Gradle Plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release CI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.0.0
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1.1.0
+
+      - name: Configure JDK
+        uses: actions/setup-java@v3.12.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Publish Gradle Plugin
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: ./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow named "Release CI" which is triggered upon pushing a new tag that starts with v, indicating a version release.

**Features & Steps:**

1. **Checkout Project:** Checks out the latest code from the repository.
2. **Validate Gradle Wrapper:** Ensures the integrity of the Gradle wrapper in the project.
3. **Configure JDK:** Sets up JDK 17 with caching enabled for Gradle builds.
4. **Grant Execution Permission:** Makes gradlew executable to ensure smooth build operations.
5. **Create Release:** Drafts a new GitHub release with the name and tag of the pushed version. This release is set as a draft, allowing manual reviews before final publishing.
6. **Publish Gradle Plugin:** Uses the provided secrets to publish the Gradle plugin to the Gradle Plugin Portal.

This workflow streamlines the process of releasing a new version of the Gradle plugin, from creating release to publishing it on the portal.