### PR TITLE
Fix Wrong "elseif" Code Generation instead of "if" in CMakeLists File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2
+
+### Fixed
+- Replace wrong "elseif" with "if" in generated CMakeLists file
+
 # 0.1.1
 
 ### Fixed

--- a/secretsvaultplugin/build.gradle.kts
+++ b/secretsvaultplugin/build.gradle.kts
@@ -51,4 +51,4 @@ configure<DetektExtension> {
 }
 
 group = "com.commencis.secretsvaultplugin"
-version = "0.1.1"
+version = "0.1.2"

--- a/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/KeepSecretsTask.kt
+++ b/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/KeepSecretsTask.kt
@@ -347,9 +347,10 @@ internal abstract class KeepSecretsTask : DefaultTask() {
             }
             sourceSets.groupBy { getCmakeArgumentName(it) }.forEach { map ->
                 val (cMakeArgument, sourceSetList) = map
-                sourceSetList.forEachIndexed { index, sourceSet ->
+                var isFirstSourceSet = true
+                for (sourceSet in sourceSetList) {
                     if (sourceSet == mainSourceSet) {
-                        return@forEachIndexed
+                        continue
                     }
                     val fileName = getKotlinSecretsFileName(sourceSet).removeSuffix(KOTLIN_FILE_NAME_SUFFIX)
                     textBuilder.append(
@@ -357,9 +358,10 @@ internal abstract class KeepSecretsTask : DefaultTask() {
                             sourceSet = sourceSet,
                             mappingFileName = fileName,
                             cmakeArgumentName = cMakeArgument,
-                            index == 0,
+                            isFirstSourceSet,
                         )
                     )
+                    isFirstSourceSet = false
                 }
                 if (sourceSetList.count { sourceSet -> sourceSet != mainSourceSet } > 1) {
                     textBuilder.append("\nendif()\n")


### PR DESCRIPTION
When there are secrets defined for both main and flavor-specific source-sets, `keepSecrets` task genarates `CMakeLists.txt` file which contains a conditonal code block that starts wtih `elseif` line instead of `if`, which results in a code that cannot be compiled:

```
add_library(
        mainsecrets
        SHARED
        secrets.cpp
)
elseif (sourceSet STREQUAL "flavor1")   <---- SHOULD BE if
    add_library(
            secrets
            SHARED
            ../../flavor1/cpp/secrets.cpp
    )
elseif (sourceSet STREQUAL "flavor2")
    add_library(
            secrets
            SHARED
            ../../flavor2/cpp/secrets.cpp
    )
endif()
```

This PR fixes this problem.
