### PR TITLE
Fix checking obfuscated value instead of key name on generating cpp file for secrets

### DIFF
--- a/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/KeepSecretsTask.kt
+++ b/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/KeepSecretsTask.kt
@@ -488,14 +488,15 @@ internal abstract class KeepSecretsTask : DefaultTask() {
             val (key, value) = secret
             val obfuscatedValue = Utils.encodeSecret(value, secretsVaultExtension.obfuscationKey.get())
             val cppText = secretsCpp.readText(Charset.defaultCharset())
-            if (cppText.contains(obfuscatedValue)) {
+            val keyName = "$JVM_NAME_PREFIX${secretKeyToIndexMap[key]}"
+            if (cppText.contains(keyName)) {
                 logWarning("Key already added in C++ !")
                 return@forEach
             }
             secretsCpp.appendText(
                 text = codeGenerator.getCppCode(
                     packageName = kotlinPackage,
-                    keyName = "$JVM_NAME_PREFIX${secretKeyToIndexMap[key]}",
+                    keyName = keyName,
                     obfuscatedValue = obfuscatedValue,
                     fileName = fileName.removeSuffix(KOTLIN_FILE_NAME_SUFFIX),
                 )


### PR DESCRIPTION
Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated secret key identification logic in the secrets vault task
	- Improved logging messages for better clarity and tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->