### PR TITLE
Making the Plugin Compatible with the Gradle Configuration Caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Clean build directory
+        run: |
+          ./gradlew clean --no-configuration-cache || true
+          rm -rf sampleapp/build/intermediates/lint-cache || true
+
       - name: Run build with caching enabled
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: clean build -s
+          arguments: build -s
 
       - name: Run Detekt
         run: ./gradlew detektMain

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.code.style=official
 android.useAndroidX=true
+org.gradle.configuration-cache=true

--- a/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/SecretsVaultPlugin.kt
+++ b/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/SecretsVaultPlugin.kt
@@ -3,7 +3,6 @@ package com.commencis.secretsvaultplugin
 import com.android.build.api.dsl.CommonExtension
 import com.commencis.secretsvaultplugin.extensions.CMakeExtension
 import com.commencis.secretsvaultplugin.extensions.SecretsVaultExtension
-import com.commencis.secretsvaultplugin.utils.EMPTY_STRING
 import com.commencis.secretsvaultplugin.utils.Utils
 import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
@@ -62,36 +61,39 @@ internal class SecretsVaultPlugin : Plugin<Project> {
         /**
          * Create a gradle task to keep secrets from a json file.
          */
-        project.tasks.register(TASK_KEEP_SECRETS_FROM_JSON_FILE, KeepSecretsTask::class.java).configure {
-            group = TASK_GROUP
-            description = "Re-generate and obfuscate keys from the json file and add it to your Android project"
-            pluginSourceFolder.set(unzipTaskProvider.map { task -> task.destinationDir })
-            json.set(Json { encodeDefaults = true })
-            
-            // Set extension values during configuration time
-            val secretsVaultExtension = project.extensions.getByType(SecretsVaultExtension::class.java)
-            val cMakeExtension = secretsVaultExtension.cmake.get()
-            
-            // Set project directory during configuration
-            projectDirectory.set(project.layout.projectDirectory)
-            
-            secretsFile.set(secretsVaultExtension.secretsFile)
-            sourceSetSecretsMappingFile.set(secretsVaultExtension.sourceSetSecretsMappingFile)
-            obfuscationKey.set(secretsVaultExtension.obfuscationKey)
-            appSignatures.set(secretsVaultExtension.appSignatures)
-            makeInjectable.set(secretsVaultExtension.makeInjectable)
-            cmakeProjectName.set(cMakeExtension.projectName)
-            cmakeVersion.set(cMakeExtension.version)
-            
-            // Set package name (with fallback to namespace from CommonExtension)
-            packageName.set(
-                secretsVaultExtension.packageName.map { pkg ->
-                    pkg.ifEmpty {
-                        project.extensions.findByType(CommonExtension::class.java)?.namespace.orEmpty()
+        project.tasks.register(TASK_KEEP_SECRETS_FROM_JSON_FILE, KeepSecretsTask::class.java)
+            .configure {
+                group = TASK_GROUP
+                description =
+                    "Re-generate and obfuscate keys from the json file and add it to your Android project"
+                pluginSourceFolder.set(unzipTaskProvider.map { task -> task.destinationDir })
+                json.set(Json { encodeDefaults = true })
+
+                // Set extension values during configuration time
+                val secretsVaultExtension =
+                    project.extensions.getByType(SecretsVaultExtension::class.java)
+                val cMakeExtension = secretsVaultExtension.cmake.get()
+
+                // Set project directory during configuration
+                projectDirectory.set(project.layout.projectDirectory)
+
+                secretsFile.set(secretsVaultExtension.secretsFile)
+                sourceSetSecretsMappingFile.set(secretsVaultExtension.sourceSetSecretsMappingFile)
+                obfuscationKey.set(secretsVaultExtension.obfuscationKey)
+                appSignatures.set(secretsVaultExtension.appSignatures)
+                makeInjectable.set(secretsVaultExtension.makeInjectable)
+                cmakeProjectName.set(cMakeExtension.projectName)
+                cmakeVersion.set(cMakeExtension.version)
+
+                // Set package name (with fallback to namespace from CommonExtension)
+                packageName.set(
+                    secretsVaultExtension.packageName.map { pkg ->
+                        pkg.ifEmpty {
+                            project.extensions.findByType(CommonExtension::class.java)?.namespace.orEmpty()
+                        }
                     }
-                }
-            )
-        }
+                )
+            }
     }
 
     /**
@@ -114,8 +116,14 @@ internal class SecretsVaultPlugin : Plugin<Project> {
      * @param cmakeExtension The associated [CMakeExtension] that should be linked to the [SecretsVaultExtension].
      * @return The created and configured [SecretsVaultExtension].
      */
-    private fun createSecretsVaultExtension(project: Project, cmakeExtension: CMakeExtension): SecretsVaultExtension {
-        return project.extensions.create(EXTENSION_NAME_SECRETS_VAULT, SecretsVaultExtension::class.java).apply {
+    private fun createSecretsVaultExtension(
+        project: Project,
+        cmakeExtension: CMakeExtension
+    ): SecretsVaultExtension {
+        return project.extensions.create(
+            EXTENSION_NAME_SECRETS_VAULT,
+            SecretsVaultExtension::class.java
+        ).apply {
             obfuscationKey.convention(Utils.generateObfuscationKey())
             secretsFile.convention(project.file(DEFAULT_SECRETS_FILE_NAME))
             appSignatures.convention(emptyList())

--- a/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/SecretsVaultPlugin.kt
+++ b/secretsvaultplugin/src/main/kotlin/com/commencis/secretsvaultplugin/SecretsVaultPlugin.kt
@@ -1,7 +1,9 @@
 package com.commencis.secretsvaultplugin
 
+import com.android.build.api.dsl.CommonExtension
 import com.commencis.secretsvaultplugin.extensions.CMakeExtension
 import com.commencis.secretsvaultplugin.extensions.SecretsVaultExtension
+import com.commencis.secretsvaultplugin.utils.EMPTY_STRING
 import com.commencis.secretsvaultplugin.utils.Utils
 import kotlinx.serialization.json.Json
 import org.gradle.api.Plugin
@@ -65,6 +67,30 @@ internal class SecretsVaultPlugin : Plugin<Project> {
             description = "Re-generate and obfuscate keys from the json file and add it to your Android project"
             pluginSourceFolder.set(unzipTaskProvider.map { task -> task.destinationDir })
             json.set(Json { encodeDefaults = true })
+            
+            // Set extension values during configuration time
+            val secretsVaultExtension = project.extensions.getByType(SecretsVaultExtension::class.java)
+            val cMakeExtension = secretsVaultExtension.cmake.get()
+            
+            // Set project directory during configuration
+            projectDirectory.set(project.layout.projectDirectory)
+            
+            secretsFile.set(secretsVaultExtension.secretsFile)
+            sourceSetSecretsMappingFile.set(secretsVaultExtension.sourceSetSecretsMappingFile)
+            obfuscationKey.set(secretsVaultExtension.obfuscationKey)
+            appSignatures.set(secretsVaultExtension.appSignatures)
+            makeInjectable.set(secretsVaultExtension.makeInjectable)
+            cmakeProjectName.set(cMakeExtension.projectName)
+            cmakeVersion.set(cMakeExtension.version)
+            
+            // Set package name (with fallback to namespace from CommonExtension)
+            packageName.set(
+                secretsVaultExtension.packageName.map { pkg ->
+                    pkg.ifEmpty {
+                        project.extensions.findByType(CommonExtension::class.java)?.namespace.orEmpty()
+                    }
+                }
+            )
         }
     }
 


### PR DESCRIPTION
`KeepSecretsTask` is updated to use' FileSystemOperations' and' ProjectLayout' instead of accessing the project at execution time to improve cache-friendliness.

https://docs.gradle.org/8.9/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

Issue: https://github.com/Commencis/secrets-vault-plugin/issues/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Gradle configuration cache to improve build performance.
  * Optimized CI with improved build directory cleanup and caching behavior.

* **Refactor**
  * Redesigned plugin configuration to use explicit, project-level properties for the secrets task, improving reliability and configurability.
  * Internal wiring simplified for more predictable task behavior and clearer configuration fallbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->